### PR TITLE
Kernel 6.8 supports audio without fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Asus zenbook UM3402YA on Linux
 ## Sound fix 
+**_Note:_** This is irrevelant for kernel >= 6.8
 * Work like a charm with kernel >= 6.2
 * Edit ssdt-csc3551.dsl if needed 
 * Build it


### PR DESCRIPTION
Kernel 6.8 added support for Cirrus CS35L41.
Ive tested it on openSUSE tumbleweed with 6.8.1

Source: https://wiki.archlinux.org/title/ASUS_Zenbook_UM3402YA